### PR TITLE
Increase RSA key size in RsaCheck()

### DIFF
--- a/src/Mayaqua/Encrypt.c
+++ b/src/Mayaqua/Encrypt.c
@@ -2684,7 +2684,7 @@ bool RsaCheck()
 	BIO *bio;
 	char errbuf[MAX_SIZE];
 	UINT size = 0;
-	UINT bit = 32;
+	UINT bit = 4096;
 	// Validate arguments
 
 	// Key generation

--- a/src/Mayaqua/Encrypt.c
+++ b/src/Mayaqua/Encrypt.c
@@ -2684,7 +2684,7 @@ bool RsaCheck()
 	BIO *bio;
 	char errbuf[MAX_SIZE];
 	UINT size = 0;
-	UINT bit = 4096;
+	UINT bit = RSA_KEY_SIZE;
 	// Validate arguments
 
 	// Key generation

--- a/src/Mayaqua/Encrypt.h
+++ b/src/Mayaqua/Encrypt.h
@@ -128,7 +128,7 @@ void RAND_Free_For_SoftEther();
 #define	DES_IV_SIZE					8			// DES IV size
 #define DES_BLOCK_SIZE				8			// DES block size
 #define DES3_KEY_SIZE				(8 * 3)		// 3DES key size
-#define RSA_KEY_SIZE				128			// RSA key size
+#define RSA_KEY_SIZE				4096			// RSA key size
 #define DH_KEY_SIZE					128			// DH key size
 #define	RSA_MIN_SIGN_HASH_SIZE		(15 + SHA1_HASH_SIZE)	// Minimum RSA hash size
 #define	RSA_SIGN_HASH_SIZE			(RSA_MIN_SIGN_HASH_SIZE)	// RSA hash size


### PR DESCRIPTION
32 bit is too small. 512 bit is the smallest valid length.
RSA_generate_key() will cause the following error when key size is too
small.

> error:04081078:rsa routines:rsa_builtin_keygen:key size too small

As RsaCheck() fails, this causes build failure with OpenSSL 1.1.1 [1].
FreeBSD 12 's default OpenSSL is 1.1.1.

> -- Alert: RsaCheck() --
> OpenSSL Library Init Failed. (too old?)
> Please install the latest version of OpenSSL.

Ideally, RsaCheck() should be re-written to use RSA_generate_key_ex()
since RSA_generate_key() is now deprecated but this is the easiest
workaround to fix the build with OpenSSL 1.1.1.

[1] https://lists.freebsd.org/pipermail/freebsd-pkg-fallout/Week-of-Mon-20181105/946095.html

Changes proposed in this pull request:
 - Increase RSA key size in RsaCheck() to fix the build with OpenSSL 1.1.1

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

-
