### PR TITLE
Backport RsaCheck() from latest SoftEtherVPN/SoftEtherVPN

### DIFF
--- a/src/Mayaqua/Encrypt.c
+++ b/src/Mayaqua/Encrypt.c
@@ -2679,23 +2679,35 @@ bool RsaCheckEx()
 }
 bool RsaCheck()
 {
-	RSA *rsa;
+	int ret = 0;
+	RSA *rsa = NULL;
+	BIGNUM *e = NULL;
 	K *priv_key, *pub_key;
 	BIO *bio;
 	char errbuf[MAX_SIZE];
 	UINT size = 0;
-	UINT bit = 32;
-	// Validate arguments
+	UINT bit = RSA_KEY_SIZE;
+
+	e = BN_new();
+	ret = BN_set_word(e, RSA_F4);
+	if (ret == 0)
+	{
+		BN_free(e);
+		Debug("BN_set_word: err=%s\n", ERR_error_string(ERR_get_error(), errbuf));
+		return false;
+	}
 
 	// Key generation
 	Lock(openssl_lock);
 	{
-		rsa = RSA_generate_key(bit, RSA_F4, NULL, NULL);
+		rsa = RSA_new();
+		ret = RSA_generate_key_ex(rsa, bit, e, NULL);
+		BN_free(e);
 	}
 	Unlock(openssl_lock);
-	if (rsa == NULL)
+	if (ret == 0)
 	{
-		Debug("RSA_generate_key: err=%s\n", ERR_error_string(ERR_get_error(), errbuf));
+		Debug("RSA_generate_key_ex: err=%s\n", ERR_error_string(ERR_get_error(), errbuf));
 		return false;
 	}
 

--- a/src/Mayaqua/Encrypt.h
+++ b/src/Mayaqua/Encrypt.h
@@ -128,7 +128,7 @@ void RAND_Free_For_SoftEther();
 #define	DES_IV_SIZE					8			// DES IV size
 #define DES_BLOCK_SIZE				8			// DES block size
 #define DES3_KEY_SIZE				(8 * 3)		// 3DES key size
-#define RSA_KEY_SIZE				128			// RSA key size
+#define RSA_KEY_SIZE				4096			// RSA key size
 #define DH_KEY_SIZE					128			// DH key size
 #define	RSA_MIN_SIGN_HASH_SIZE		(15 + SHA1_HASH_SIZE)	// Minimum RSA hash size
 #define	RSA_SIGN_HASH_SIZE			(RSA_MIN_SIGN_HASH_SIZE)	// RSA hash size


### PR DESCRIPTION
This is another option of #1.

RSA_generate_key() is deprecated. The latest head has a code using
RSA_generate_key_ex().

Also increase the key size. 128 bit is too small and causes build error
with OpenSSL 1.1.1.

Changes proposed in this pull request:
 - Replace RsaCheck() with the latest version brought from SoftEtherVPN/SoftEtherVPN

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- I choose option 1
