### PR TITLE
Increase Radius timeout

### DIFF
--- a/src/Cedar/Radius.h
+++ b/src/Cedar/Radius.h
@@ -107,7 +107,7 @@
 
 #define	RADIUS_DEFAULT_PORT		1812			// The default port number
 #define	RADIUS_RETRY_INTERVAL	500				// Retransmission interval
-#define	RADIUS_RETRY_TIMEOUT	(10 * 1000)		// Time-out period
+#define	RADIUS_RETRY_TIMEOUT	(15 * 1000)		// Time-out period, keep it 2FA friendly
 #define	RADIUS_INITIAL_EAP_TIMEOUT	1600		// Initial timeout for EAP
 
 

--- a/src/Cedar/Radius.h
+++ b/src/Cedar/Radius.h
@@ -106,7 +106,7 @@
 #define	RADIUS_H
 
 #define	RADIUS_DEFAULT_PORT		1812			// The default port number
-#define	RADIUS_RETRY_INTERVAL	500				// Retransmission interval
+#define	RADIUS_RETRY_INTERVAL	1000				// Retransmission interval
 #define	RADIUS_RETRY_TIMEOUT	(15 * 1000)		// Time-out period, keep it 2FA friendly
 #define	RADIUS_INITIAL_EAP_TIMEOUT	1600		// Initial timeout for EAP
 


### PR DESCRIPTION
Hello,

This PR increases by a little Radius timeout.
This to make SoftEtherVPN 2FA friendly.
Radius may be set to ask for a second authentication factor (through a push notification / validation for example), the default 10 seconds are then really short here.
15 seconds seem more reasonable to let users validate the second authentication factor.

Thank you very much for your help & support 👍

-----

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- I did not found any of the mentioned options, but of course I accept my code to reach SoftEtherVPN under its current license.
