### PR TITLE
Log client IP in failed accesses

### DIFF
--- a/src/Cedar/Protocol.c
+++ b/src/Cedar/Protocol.c
@@ -2935,8 +2935,11 @@ bool ServerAccept(CONNECTION *c)
 
 				if (auth_ret == false)
 				{
+					// Get client IP to feed tools such as Fail2Ban
+					char ip[64];
+					IPToStr(ip, sizeof(ip), &c->FirstSock->RemoteIP);
 					// Authentication failure
-					HLog(hub, "LH_AUTH_NG", c->Name, username);
+					HLog(hub, "LH_AUTH_NG", c->Name, username, ip);
 				}
 				else
 				{

--- a/src/bin/hamcore/strtable_cn.stb
+++ b/src/bin/hamcore/strtable_cn.stb
@@ -1921,7 +1921,7 @@ LH_AUTH_CERT_NOT_SUPPORT_ON_OPEN_SOURCE	"%S" 的连接方法: 用户 "%S" 的身
 LH_AUTH_OK					连接 "%S": 成功认证为用户 "%S"。
 LH_AUTH_OK_CERT				虚拟 HUB 的安全账户管理器已经从 VPN Client 接收到如下证书，且接受了其内容作为当用户 "%S" 登录时的证书: %s
 LH_AUTH_NG_CERT				虚拟 HUB 的安全账户管理器已经从 VPN Client 接收到如下证书，但拒绝了其内容作为当用户 "%S" 登录时的证书，因为此证书的内容匹配虚拟 HUB 中注册的废止内容列表: %s
-LH_AUTH_NG					连接 "%S": 用户认证失败。提供的用户名为 "%S"。
+LH_AUTH_NG					Connection "%S": User authentication failed. The user name that has been provided was "%S", from %S.
 LH_LOCAL_ONLY				连接 "%S": 远程登录拒绝，因为用户 "%S" 的密码为空。
 LH_POLICY_ACCESS_NG			连接 "%S": 由于安全策略，用户 "%S" 拒绝访问。
 LH_USER_EXPIRES				连接 "%S": 由于有效期限已过，用户 "%S" 拒绝访问。

--- a/src/bin/hamcore/strtable_en.stb
+++ b/src/bin/hamcore/strtable_en.stb
@@ -1903,7 +1903,7 @@ LH_AUTH_CERT_NOT_SUPPORT_ON_OPEN_SOURCE	Connection "%S": The authentication meth
 LH_AUTH_OK				Connection "%S": Successfully authenticated as user "%S".
 LH_AUTH_OK_CERT			The Virtual Hub's Security Account Manager has received the following certificate from the VPN Client and accepted its contents as the certificate for when user "%S" logs in: %s
 LH_AUTH_NG_CERT			Although the Virtual Hub's Security Account Manager has received the following certificate, has refused its contents as the certificate for when user "%S" logs in because this certificate's contents matches the contents that are registered in the Virtual Hub's certificates revocation list: %s
-LH_AUTH_NG				Connection "%S": User authentication failed. The user name that has been provided was "%S".
+LH_AUTH_NG				Connection "%S": User authentication failed. The user name that has been provided was "%S", from %S.
 LH_LOCAL_ONLY			Connection "%S": The remote login has been refused because of the password for user "%S" is blank.
 LH_POLICY_ACCESS_NG		Connection "%S": Access has beens refused to user "%S" based on the security policy.
 LH_USER_EXPIRES			Connection "%S": Access has been refused to user "%S" because of the expiration date has been expired.

--- a/src/bin/hamcore/strtable_ja.stb
+++ b/src/bin/hamcore/strtable_ja.stb
@@ -1909,7 +1909,7 @@ LH_AUTH_CERT_NOT_SUPPORT_ON_OPEN_SOURCE	コネクション "%S": ユーザー "%
 LH_AUTH_OK				コネクション "%S": ユーザー "%S" として正しく認証されました。
 LH_AUTH_OK_CERT			仮想 HUB のセキュリティアカウントマネージャは、ユーザー "%S" がログインする際の証明書として、次の証明書を VPN Client から受理し、その内容を承認しました: %s
 LH_AUTH_NG_CERT			仮想 HUB のセキュリティアカウントマネージャは、ユーザー "%S" がログインする際の証明書として、次の証明書を VPN Client から受理しましたが、この証明書は仮想 HUB の無効な証明書一覧に登録されている内容に一致するため拒否しました: %s
-LH_AUTH_NG				コネクション "%S": ユーザー認証に失敗しました。提示されたユーザー名は "%S" でした。
+LH_AUTH_NG				Connection "%S": User authentication failed. The user name that has been provided was "%S", from %S.
 LH_LOCAL_ONLY			コネクション "%S": ユーザー "%S" のパスワードが空白のため、リモートからのログインは拒否されました。
 LH_POLICY_ACCESS_NG		コネクション "%S": ユーザー "%S" はセキュリティポリシーによってアクセスが拒否されています。
 LH_USER_EXPIRES			コネクション "%S": ユーザー "%S" の有効期限が切れており、アクセスが拒否されました。


### PR DESCRIPTION
Hello,

This PR adds the client IP in the `LH_AUTH_NG` message, the authentication failure message.
This allow to use tools such as Fail2Ban to ban IPs with too many authentication failures / retries.

Thank you very much for your help & support 👍

-----

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- I did not found any of the mentioned options, but of course I accept my code to reach SoftEtherVPN under its current license.