### PR TITLE
Update softether-vpnserver.service

### DIFF
--- a/systemd/softether-vpnserver.service
+++ b/systemd/softether-vpnserver.service
@@ -17,7 +17,7 @@ ProtectHome=yes
 ProtectSystem=full
 ReadOnlyDirectories=/
 ReadWriteDirectories=-/opt/vpnserver
-CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_BROADCAST CAP_NET_RAW CAP_SYS_NICE CAP_SYS_ADMIN CAP_SETUID
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_BROADCAST CAP_NET_RAW CAP_SYS_NICE CAP_SYS_ADMIN CAP_SETUID CAP_SETGID
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I could not start SoftEtherVPN Server properly without "CAP_SETGID" in the "CapabilityBoundingSet" setting.

Changes proposed in this pull request:
 - Add "CAP_SETGID" in the "CapabilityBoundingSet" 
 - 
 - 

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- I accept it.
