### PR TITLE
Fix Unix compilation when using GCC 14.x

### DIFF
--- a/src/Cedar/Console.c
+++ b/src/Cedar/Console.c
@@ -1981,6 +1981,14 @@ char *ParseCommandA(wchar_t *str, char *name)
 	return ret;
 }
 
+#ifndef	OS_WIN32
+	// use a simple wrapper to create a compatible function,
+	// allowing for uniform use of getch() below
+	static int getch(void) {
+		return getc(stdin);
+	}
+#endif	// OS_WIN32
+
 // Password prompt
 bool PasswordPrompt(char *password, UINT size)
 {
@@ -2005,13 +2013,7 @@ bool PasswordPrompt(char *password, UINT size)
 
 	while (true)
 	{
-		int c;
-
-#ifdef	OS_WIN32
-		c = getch();
-#else	// OS_WIN32
-		c = getc(stdin);
-#endif	// OS_WIN32
+		int c = getch();
 
 		if (c >= 0x20 && c <= 0x7E)
 		{

--- a/src/Cedar/VLanUnix.h
+++ b/src/Cedar/VLanUnix.h
@@ -122,6 +122,7 @@ struct VLAN
 VLAN *NewVLan(char *instance_name, VLAN_PARAM *param);
 VLAN *NewTap(char *name, char *mac_address);
 void FreeVLan(VLAN *v);
+void FreeTap(VLAN *v);
 CANCEL *VLanGetCancel(VLAN *v);
 bool VLanGetNextPacket(VLAN *v, void **buf, UINT *size);
 bool VLanPutPacket(VLAN *v, void *buf, UINT size);

--- a/src/Mayaqua/Secure.c
+++ b/src/Mayaqua/Secure.c
@@ -1710,7 +1710,7 @@ void CloseSecSession(SECURE *sec)
 }
 
 // Open the session
-bool OpenSecSession(SECURE *sec, UINT slot_number)
+bool OpenSecSession(SECURE *sec, CK_SLOT_ID slot_number)
 {
 	UINT err = 0;
 	CK_SESSION_HANDLE session;
@@ -1835,7 +1835,7 @@ SECURE *OpenSec(UINT id)
 		return NULL;
 	}
 
-	sec->SlotIdList = (CK_SLOT_ID *)ZeroMalloc(sizeof(UINT) * sec->NumSlot);
+	sec->SlotIdList = (CK_SLOT_ID *)ZeroMalloc(sizeof(CK_SLOT_ID) * sec->NumSlot);
 
 	if (sec->Api->C_GetSlotList(TRUE, sec->SlotIdList, &sec->NumSlot) != CKR_OK)
 	{

--- a/src/Mayaqua/Secure.c
+++ b/src/Mayaqua/Secure.c
@@ -370,7 +370,7 @@ bool SignSec(SECURE *sec, char *name, void *dst, void *src, UINT size)
 }
 
 // Sign with the private key of the secure device
-bool SignSecByObject(SECURE *sec, SEC_OBJ *obj, void *dst, void *src, UINT size)
+bool SignSecByObject(SECURE *sec, SEC_OBJ *obj, void *dst, void *src, CK_ULONG size)
 {
 	CK_MECHANISM mechanism = {CKM_RSA_PKCS, NULL, 0};
 	UINT ret;
@@ -474,7 +474,7 @@ bool WriteSecKey(SECURE *sec, bool private_obj, char *name, K *k)
 	UINT key_type = CKK_RSA;
 	CK_BBOOL b_true = true, b_false = false, b_private_obj = private_obj;
 	UINT obj_class = CKO_PRIVATE_KEY;
-	UINT object;
+	CK_OBJECT_HANDLE object;
 	UINT ret;
 	BUF *b;
 	RSA *rsa;
@@ -716,7 +716,7 @@ bool WriteSecCert(SECURE *sec, bool private_obj, char *name, X *x)
 	UCHAR value[4096];
 	UINT ret;
 	BUF *b;
-	UINT object;
+	CK_OBJECT_HANDLE object;
 	CK_ATTRIBUTE a[] =
 	{
 		{CKA_SUBJECT,			subject,		0},			// 0
@@ -1264,8 +1264,8 @@ LIST *CloneEnumSecObject(LIST *o)
 LIST *EnumSecObject(SECURE *sec)
 {
 	CK_BBOOL b_true = true, b_false = false;
-	UINT objects[MAX_OBJ];
-	UINT i;
+	CK_OBJECT_HANDLE objects[MAX_OBJ];
+	CK_ULONG i;
 	UINT ret;
 	LIST *o;
 	CK_ATTRIBUTE dummy[1];
@@ -1273,7 +1273,7 @@ LIST *EnumSecObject(SECURE *sec)
 	{
 		{CKA_TOKEN,		&b_true,		sizeof(b_true)},
 	};
-	UINT num_objects = MAX_OBJ;
+	CK_ULONG num_objects = MAX_OBJ;
 	// Validate arguments
 	if (sec == NULL)
 	{
@@ -1389,7 +1389,7 @@ bool WriteSecData(SECURE *sec, bool private_obj, char *name, void *data, UINT si
 {
 	UINT object_class = CKO_DATA;
 	CK_BBOOL b_true = true, b_false = false, b_private_obj = private_obj;
-	UINT object;
+	CK_OBJECT_HANDLE object;
 	CK_ATTRIBUTE a[] =
 	{
 		{CKA_TOKEN,		&b_true,		sizeof(b_true)},
@@ -1713,7 +1713,7 @@ void CloseSecSession(SECURE *sec)
 bool OpenSecSession(SECURE *sec, UINT slot_number)
 {
 	UINT err = 0;
-	UINT session;
+	CK_SESSION_HANDLE session;
 	// Validate arguments
 	if (sec == NULL)
 	{
@@ -1835,7 +1835,7 @@ SECURE *OpenSec(UINT id)
 		return NULL;
 	}
 
-	sec->SlotIdList = (UINT *)ZeroMalloc(sizeof(UINT) * sec->NumSlot);
+	sec->SlotIdList = (CK_SLOT_ID *)ZeroMalloc(sizeof(UINT) * sec->NumSlot);
 
 	if (sec->Api->C_GetSlotList(TRUE, sec->SlotIdList, &sec->NumSlot) != CKR_OK)
 	{

--- a/src/Mayaqua/Secure.h
+++ b/src/Mayaqua/Secure.h
@@ -162,7 +162,7 @@ struct SECURE
 	CK_SLOT_ID *SlotIdList;					// Slot ID list
 	bool SessionCreated;					// Session creation flags
 	UINT SessionId;							// Session ID
-	UINT SessionSlotNumber;					// Slot ID of the session
+	CK_SLOT_ID SessionSlotNumber;			// Slot ID of the session
 	bool LoginFlag;							// Logged-in flag
 	SEC_INFO *Info;							// Token information
 	LIST *EnumCache;						// Enumeration cache
@@ -220,7 +220,7 @@ bool CheckSecureDeviceId(UINT id);
 SECURE_DEVICE *GetSecureDevice(UINT id);
 SECURE *OpenSec(UINT id);
 void CloseSec(SECURE *sec);
-bool OpenSecSession(SECURE *sec, UINT slot_number);
+bool OpenSecSession(SECURE *sec, CK_SLOT_ID slot_number);
 void CloseSecSession(SECURE *sec);
 bool LoginSec(SECURE *sec, char *pin);
 void LogoutSec(SECURE *sec);

--- a/src/Mayaqua/Secure.h
+++ b/src/Mayaqua/Secure.h
@@ -109,6 +109,7 @@
 #define	MAX_SEC_DATA_SIZE		4096
 
 // Type declaration related to PKCS#11
+#include "cryptoki.h"
 #ifndef	SECURE_C
 typedef struct CK_FUNCTION_LIST *CK_FUNCTION_LIST_PTR;
 typedef struct SEC_DATA_WIN32	SEC_DATA_WIN32;
@@ -157,8 +158,8 @@ struct SECURE
 	UINT Error;								// The error that last occurred
 	struct CK_FUNCTION_LIST *Api;			// API
 	bool Initialized;						// Initialization flag
-	UINT NumSlot;							// The number of slots
-	UINT *SlotIdList;						// Slot ID list
+	CK_ULONG NumSlot;						// The number of slots
+	CK_SLOT_ID *SlotIdList;					// Slot ID list
 	bool SessionCreated;					// Session creation flags
 	UINT SessionId;							// Session ID
 	UINT SessionSlotNumber;					// Slot ID of the session
@@ -247,7 +248,7 @@ X *ReadSecCertFromObject(SECURE *sec, SEC_OBJ *obj);
 X *ReadSecCert(SECURE *sec, char *name);
 bool WriteSecKey(SECURE *sec, bool private_obj, char *name, K *k);
 bool DeleteSecKey(SECURE *sec, char *name);
-bool SignSecByObject(SECURE *sec, SEC_OBJ *obj, void *dst, void *src, UINT size);
+bool SignSecByObject(SECURE *sec, SEC_OBJ *obj, void *dst, void *src, CK_ULONG size);
 bool SignSec(SECURE *sec, char *name, void *dst, void *src, UINT size);
 bool ChangePin(SECURE *sec, char *old_pin, char *new_pin);
 void TestSec();

--- a/src/Mayaqua/Unix.c
+++ b/src/Mayaqua/Unix.c
@@ -309,9 +309,8 @@ OS_DISPATCH_TABLE *UnixGetDispatchTable()
 	return &t;
 }
 
-static void *signal_received_for_ignore(int sig, siginfo_t *info, void *ucontext) 
+static void signal_received_for_ignore(int sig, siginfo_t *info, void *ucontext)
 {
-	return NULL;
 }
 
 // Ignore the signal flew to the thread


### PR DESCRIPTION
GCC 14 defaults to stricter type checking, causing compilation errors that result in a build failure with the current source code (v4.44 9807 rtm).

This patch addresses these to get the (Unix) build working again.

Tested with gcc 14.3.0 on Gentoo Linux.

Regards, NiteHawk