### PR TITLE
Eraser skips client_log folder and runs every 300 ms by default instead of every 5 minutes

### DIFF
--- a/src/Cedar/Logging.c
+++ b/src/Cedar/Logging.c
@@ -119,6 +119,7 @@ static char *delete_targets[] =
 	"bridge_log",
 	"packet_log_archive",
 	"azure_log",
+	"client_log",
 };
 
 static UINT eraser_check_interval = DISK_FREE_CHECK_INTERVAL_DEFAULT;
@@ -487,21 +488,14 @@ void SetEraserCheckInterval(UINT interval)
 	}
 	else
 	{
-		eraser_check_interval = interval * 1000;
+		eraser_check_interval = interval;
 	}
 }
 
 // Get the interval for disk free space check
 UINT GetEraserCheckInterval()
 {
-	UINT ret = eraser_check_interval / 1000;
-
-	if (ret == 0)
-	{
-		ret = 1;
-	}
-
-	return ret;
+	return eraser_check_interval;
 }
 
 // Create a new eraser

--- a/src/Cedar/Server.c
+++ b/src/Cedar/Server.c
@@ -5970,7 +5970,7 @@ void SiLoadServerCfg(SERVER *s, FOLDER *f)
 		s->DisableDeadLockCheck = CfgGetBool(f, "DisableDeadLockCheck");
 
 		// Eraser
-		SetEraserCheckInterval(CfgGetInt(f, "AutoDeleteCheckIntervalSecs"));
+		SetEraserCheckInterval(CfgGetInt(f, "AutoDeleteCheckIntervalSecs") * 1000);
 		s->Eraser = NewEraser(s->Logger, CfgGetInt64(f, "AutoDeleteCheckDiskFreeSpaceMin"));
 
 		// WebUI
@@ -6391,7 +6391,7 @@ void SiWriteServerCfg(FOLDER *f, SERVER *s)
 
 		// Eraser related
 		CfgAddInt64(f, "AutoDeleteCheckDiskFreeSpaceMin", s->Eraser->MinFreeSpace);
-		CfgAddInt(f, "AutoDeleteCheckIntervalSecs", GetEraserCheckInterval());
+		CfgAddInt(f, "AutoDeleteCheckIntervalSecs", GetEraserCheckInterval() / 1000);
 
 		// WebUI
 		CfgAddBool(f, "UseWebUI", s->UseWebUI);


### PR DESCRIPTION
Hello - thank you for all the hard work on this project.
I believe I've run into 2 bugs regarding the Logging Eraser:

fix: Eraser was running every 300 ms by default instead of every 5 minutes
fix: Eraser was not erasing the `client_log` folder

Changes proposed in this pull request:
 - The conversion from milliseconds to seconds and back now happens outside of the Logger.c functions, fixing the bug
 - Added the `client_log` folder to the list of delete targets

Thanks!